### PR TITLE
Fix Postgres connection string for ar_layer

### DIFF
--- a/lib/simpler_tiles/map.rb
+++ b/lib/simpler_tiles/map.rb
@@ -31,7 +31,7 @@ module SimplerTiles
         :password => config[:password]
       }
 
-      layer "PG:#{params.map {|k,v| "#{k}='#{v}' "}}"
+      layer "PG:" + params.map {|k,v| "#{k}='#{v}'"}.join(' ')
     end
 
     # Render the data to a blob of png data.


### PR DESCRIPTION
The PG connection string generation for Map.ar_layer generates a string that OGR doesn't like:

PG:["dbname='foobar_development' ", "user='foobar' ", "host=''", "port=''", "password='foobar' "]

I have corrected it so the string looks like this:

"PG:dbname='foobar_development' user='foobar' host='' port='' password='foobar'"

This is using MacOS 10.6, with dependencies installed from homebrew, MRI ruby 1.9.3 with the performance patches, Postgres 9.2, and PostGIS 2.0.
